### PR TITLE
Some usability improvements + tests/docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "priority-queue"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Gianmarco Garrisi <gianmarcogarrisi@tutanota.com>"]
 description = "A Priority Queue implemented as a heap with a function to efficiently change the priority of an item."
 repository = "https://github.com/garro95/priority-queue"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,8 @@
 //!     }
 //! }
 //! ```
-
+#![feature(test)]
+extern crate test;
 extern crate indexmap;
 #[cfg(all(feature = "serde", test))]
 #[macro_use]
@@ -66,6 +67,7 @@ pub use crate::pqueue::PriorityQueue;
 #[cfg(test)]
 mod tests {
     pub use crate::PriorityQueue;
+    use test::{black_box, Bencher};
 
     #[test]
     fn init() {
@@ -329,6 +331,29 @@ mod tests {
         use std::time::*;
         type PqType = PriorityQueue<i32, Instant>;
         let _: PqType = PriorityQueue::default();
+    }
+
+    #[bench]
+    fn push_and_pop(b: &mut Bencher) {
+        type PqType = PriorityQueue<usize, i32>;
+        let mut pq: PqType = PriorityQueue::new();
+        b.iter(|| {
+            pq.push(black_box(0), black_box(0));
+            assert_eq![pq.pop().unwrap().1, 0];
+        });
+    }
+
+    #[bench]
+    fn push_and_pop_on_large_queue(b: &mut Bencher) {
+        type PqType = PriorityQueue<usize, i32>;
+        let mut pq: PqType = PriorityQueue::new();
+        for i in 0..100_000 {
+            pq.push(black_box(i as usize), black_box(i));
+        }
+        b.iter(|| {
+            pq.push(black_box(100_000), black_box(100_000));
+            assert_eq![pq.pop().unwrap().1, black_box(100_000)];
+        });
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,13 @@ mod tests {
         assert_eq!(a, b);
         assert_eq!(b, a);
     }
+
+    #[test]
+    fn non_default_key() {
+        use std::time::*;
+        type PqType = PriorityQueue<i32, Instant>;
+        let _: PqType = PriorityQueue::default();
+    }
 }
 
 #[cfg(all(feature = "serde", test))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,15 @@ mod tests {
     }
 
     #[test]
+    fn reversed_order() {
+        use std::cmp::Reverse;
+        let mut pq: PriorityQueue<_, Reverse<i32>> = PriorityQueue::new();
+        pq.push("a", Reverse(1));
+        pq.push("b", Reverse(2));
+        assert_eq![pq.pop(), Some(("a", Reverse(1)))];
+    }
+
+    #[test]
     fn from_vec() {
         let v = vec![("a", 1), ("b", 2), ("f", 7)];
         let mut pq = PriorityQueue::from(v);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! extern crate priority_queue;
 //!
 //! use priority_queue::PriorityQueue;
-//!       
+//!
 //! fn main() {
 //!     let mut pq = PriorityQueue::new();
 //!
@@ -45,7 +45,7 @@
 //!     pq.push("Strawberries", 23);
 //!
 //!     assert_eq!(pq.peek(), Some((&"Strawberries", &23)));
-//!     
+//!
 //!     pq.change_priority("Bananas", 25);
 //!     assert_eq!(pq.peek(), Some((&"Bananas", &25)));
 //!

--- a/src/pqueue.rs
+++ b/src/pqueue.rs
@@ -268,6 +268,9 @@ where
     /// Change the priority of an Item returning the old value of priority,
     /// or `None` if the item wasn't in the queue.
     ///
+    /// The argument `item` is only used for lookup, and is not used to overwrite the item's data
+    /// in the priority queue.
+    ///
     /// The item is found in **O(1)** thanks to the hash table.
     /// The operation is performed in **O(log(N))** time.
     pub fn change_priority<Q: ?Sized>(&mut self, item: &Q, new_priority: P) -> Option<P>

--- a/src/pqueue.rs
+++ b/src/pqueue.rs
@@ -394,7 +394,7 @@ where
         self.map.into_iter().map(|(i, _)| i).collect()
     }
 
-    /// Implements an HeapSort
+    /// Implements a HeapSort
     pub fn into_sorted_vec(mut self) -> Vec<I> {
         let mut res = Vec::with_capacity(self.size);
         while let Some((i, _)) = self.pop() {

--- a/src/pqueue.rs
+++ b/src/pqueue.rs
@@ -37,7 +37,7 @@ use indexmap::map::{IndexMap, MutableKeys};
 ///
 /// Implemented as a heap of indexes, stores the items inside an `IndexMap`
 /// to be able to retrieve them quickly.
-#[derive(Clone, Default, Eq)]
+#[derive(Clone, Eq)]
 pub struct PriorityQueue<I, P>
 where
     I: Hash + Eq,
@@ -48,6 +48,12 @@ where
     qp: Vec<usize>,                         // Performs the translation from the index
     // of the map to the index of the heap
     size: usize, // The size of the heap
+}
+
+impl<I: Hash + Eq, P: Ord> Default for PriorityQueue<I, P> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<I, P> PriorityQueue<I, P>


### PR DESCRIPTION
I'm using this crate to implement a timer-based reactor for callbacks, unfortunately `std::time::Instant` does not `impl Default` so I can't create a default object of `PriorityQueue`.

There is no good reason for `P` to be `Default`, so this patch series implements `Default` manually by relegating to `new`, which works for all `P: Ord`. Deriving default appears to add a hidden requirement for `P: Default`.