### PR TITLE
Remove take_mut dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ travis-ci = { repository = "garro95/priority-queue", branch = "master" }
 [dependencies]
 indexmap = "1"
 serde = {version = "1", optional = true}
-take_mut = "0.2"
 
 [dev-dependencies]
 serde_test = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,7 @@ mod tests {
         let v = vec![("a", 1), ("b", 2), ("f", 7), ("g", 6), ("h", 5)];
         let mut pq = PriorityQueue::from_iter(v.into_iter());
 
-        pq.change_priority_by("b", |b| b + 8);
+        pq.change_priority_by("b", |b| *b += 8);
         assert_eq!(pq.into_sorted_vec().as_slice(), &["b", "f", "g", "h", "a"]);
     }
 

--- a/src/pqueue.rs
+++ b/src/pqueue.rs
@@ -29,7 +29,6 @@ use std::iter::Iterator;
 use std::mem::{replace, swap};
 
 use indexmap::map::{IndexMap, MutableKeys};
-use take_mut::take;
 
 /// A priority queue with efficient change function to change the priority of an
 /// element.
@@ -427,12 +426,12 @@ where
     where
         I: Borrow<Q>,
         Q: Eq + Hash,
-        F: FnOnce(P) -> P,
+        F: FnOnce(&mut P),
     {
         let mut pos = 0;
         let mut found = false;
-        if let Some((index, _, p)) = self.map.get_full_mut(item) {
-            take(p, priority_setter);
+        if let Some((index, _, mut p)) = self.map.get_full_mut(item) {
+            priority_setter(&mut p);
             pos = unsafe { *self.qp.get_unchecked(index) };
             found = true;
         }


### PR DESCRIPTION
Hi, I was looking for a crate that can keep a priority queue with priorities that change over time, and found your crate, which looks like a good candidate. I noticed that your crate depends on the `take_mut` crate, which makes use of `unsafe` in order to (temporarily) get a `T` from a `&mut T`. I checked to see where this code was being used, and found that it is actually possible to avoid `unsafe` there, by replacing `FnOnce(P) -> P` by `FnOnce(&mut P)`. 

My pull request includes this change, which I believe preserves the functionality of this library while reducing the amount of `unsafe` code that needs to be vetted (the `unsafe` code in `take_mut` is non-trivial). I think that with this change, the only `unsafe` code left in this library is accessing elements of a vector without a bounds check, which is totally fine and expected for a crate like this. I'd be happy to hear if you have any thoughts or questions about this change.