### PR TITLE
Make `change_priority` API consistent

### DIFF
--- a/src/double_priority_queue/mod.rs
+++ b/src/double_priority_queue/mod.rs
@@ -472,17 +472,24 @@ where
     }
 
     /// Change the priority of an Item using the provided function.
+    /// or `None` if the item wasn't in the queue.
+    ///
+    /// The argument `item` is only used for lookup, and is not used to overwrite the item's data
+    /// in the priority queue.
+    ///
     /// The item is found in **O(1)** thanks to the hash table.
     /// The operation is performed in **O(log(N))** time (worst case).
-    pub fn change_priority_by<Q: ?Sized, F>(&mut self, item: &Q, priority_setter: F)
+    pub fn change_priority_by<Q: ?Sized, F>(&mut self, item: &Q, priority_setter: F) -> Option<()>
     where
         I: Borrow<Q>,
         Q: Eq + Hash,
         F: FnOnce(&mut P),
     {
-        if let Some(pos) = self.store.change_priority_by(item, priority_setter) {
-            self.up_heapify(pos);
-        }
+        self.store
+            .change_priority_by(item, priority_setter)
+            .map(|pos| {
+                self.up_heapify(pos);
+            })
     }
 
     /// Get the priority of an item, or `None`, if the item is not in the queue

--- a/src/double_priority_queue/mod.rs
+++ b/src/double_priority_queue/mod.rs
@@ -489,7 +489,8 @@ where
             .change_priority_by(item, priority_setter)
             .map(|pos| {
                 self.up_heapify(pos);
-            }).is_some()
+            })
+            .is_some()
     }
 
     /// Get the priority of an item, or `None`, if the item is not in the queue

--- a/src/double_priority_queue/mod.rs
+++ b/src/double_priority_queue/mod.rs
@@ -472,14 +472,14 @@ where
     }
 
     /// Change the priority of an Item using the provided function.
-    /// or `None` if the item wasn't in the queue.
+    /// Return a boolean value where `true` means the item was in the queue and update was successful
     ///
     /// The argument `item` is only used for lookup, and is not used to overwrite the item's data
     /// in the priority queue.
     ///
     /// The item is found in **O(1)** thanks to the hash table.
     /// The operation is performed in **O(log(N))** time (worst case).
-    pub fn change_priority_by<Q: ?Sized, F>(&mut self, item: &Q, priority_setter: F) -> Option<()>
+    pub fn change_priority_by<Q: ?Sized, F>(&mut self, item: &Q, priority_setter: F) -> bool
     where
         I: Borrow<Q>,
         Q: Eq + Hash,
@@ -489,7 +489,7 @@ where
             .change_priority_by(item, priority_setter)
             .map(|pos| {
                 self.up_heapify(pos);
-            })
+            }).is_some()
     }
 
     /// Get the priority of an item, or `None`, if the item is not in the queue

--- a/src/priority_queue/mod.rs
+++ b/src/priority_queue/mod.rs
@@ -406,14 +406,14 @@ where
     }
 
     /// Change the priority of an Item using the provided function.
-    /// or `None` if the item wasn't in the queue.
+    /// Return a boolean value where `true` means the item was in the queue and update was successful
     ///
     /// The argument `item` is only used for lookup, and is not used to overwrite the item's data
     /// in the priority queue.
     ///
     /// The item is found in **O(1)** thanks to the hash table.
     /// The operation is performed in **O(log(N))** time (worst case).
-    pub fn change_priority_by<Q: ?Sized, F>(&mut self, item: &Q, priority_setter: F) -> Option<()>
+    pub fn change_priority_by<Q: ?Sized, F>(&mut self, item: &Q, priority_setter: F) -> bool
     where
         I: Borrow<Q>,
         Q: Eq + Hash,
@@ -423,7 +423,7 @@ where
             .change_priority_by(item, priority_setter)
             .map(|pos| {
                 self.up_heapify(pos);
-            })
+            }).is_some()
     }
 
     /// Get the priority of an item, or `None`, if the item is not in the queue

--- a/src/priority_queue/mod.rs
+++ b/src/priority_queue/mod.rs
@@ -406,17 +406,24 @@ where
     }
 
     /// Change the priority of an Item using the provided function.
+    /// or `None` if the item wasn't in the queue.
+    ///
+    /// The argument `item` is only used for lookup, and is not used to overwrite the item's data
+    /// in the priority queue.
+    ///
     /// The item is found in **O(1)** thanks to the hash table.
     /// The operation is performed in **O(log(N))** time (worst case).
-    pub fn change_priority_by<Q: ?Sized, F>(&mut self, item: &Q, priority_setter: F)
+    pub fn change_priority_by<Q: ?Sized, F>(&mut self, item: &Q, priority_setter: F) -> Option<()>
     where
         I: Borrow<Q>,
         Q: Eq + Hash,
         F: FnOnce(&mut P),
     {
-        if let Some(pos) = self.store.change_priority_by(item, priority_setter) {
-            self.up_heapify(pos);
-        }
+        self.store
+            .change_priority_by(item, priority_setter)
+            .map(|pos| {
+                self.up_heapify(pos);
+            })
     }
 
     /// Get the priority of an item, or `None`, if the item is not in the queue

--- a/src/priority_queue/mod.rs
+++ b/src/priority_queue/mod.rs
@@ -423,7 +423,8 @@ where
             .change_priority_by(item, priority_setter)
             .map(|pos| {
                 self.up_heapify(pos);
-            }).is_some()
+            })
+            .is_some()
     }
 
     /// Get the priority of an item, or `None`, if the item is not in the queue

--- a/tests/double_priority_queue.rs
+++ b/tests/double_priority_queue.rs
@@ -259,9 +259,9 @@ mod doublepq_tests {
         let v = vec![("a", 1), ("b", 2), ("f", 7), ("g", 6), ("h", 5)];
         let mut pq: DoublePriorityQueue<_, _> = DoublePriorityQueue::from_iter(v.into_iter());
 
-        pq.change_priority_by("z", |z| *z += 8);
+        assert!(!pq.change_priority_by("z", |z| *z += 8));
 
-        pq.change_priority_by("b", |b| *b += 8);
+        assert!(pq.change_priority_by("b", |b| *b += 8));
         assert_eq!(
             pq.into_descending_sorted_vec().as_slice(),
             &["b", "f", "g", "h", "a"]

--- a/tests/priority_queue.rs
+++ b/tests/priority_queue.rs
@@ -249,7 +249,7 @@ mod pqueue_tests {
         let v = vec![("a", 1), ("b", 2), ("f", 7), ("g", 6), ("h", 5)];
         let mut pq: PriorityQueue<_, _> = PriorityQueue::from_iter(v.into_iter());
 
-        pq.change_priority_by("b", |b| *b += 8);
+        assert!(pq.change_priority_by("b", |b| *b += 8));
         assert_eq!(pq.into_sorted_vec().as_slice(), &["b", "f", "g", "h", "a"]);
     }
 


### PR DESCRIPTION
Currently for either `PriorityQueue` or `DoublePriorityQueue`, the return value for `change_priority` and `change_priority_by` functions are different.

In some cases where a customized (and complicated) struct P is used, `change_priority_by` is usually preferred which provides flexibility to update the underlying structure. However, due to nothing is returned, the caller has no idea whether the update is successful or not. There are few options
1. make `change_priority_by` return an `Option` type (same as `change_priority`
2. Call `get_priority` first. Based on result and then call `change_priority_by`
3. Call `push`

2 and 3 are obviously not ideal, as Option2 caused IndexMap lookup twice; Option3 may cause a clone
This PR submits code change for Option1