### PR TITLE
Add explicit MPL-2.0 licence notice "Exhibit A"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,20 @@ documentation = "https://docs.rs/priority-queue"
 readme = "README.md"
 keywords = ["priority", "queue", "heap"]
 categories = ["data-structures", "algorithms"]
-license = "LGPL-3.0 OR MPL-2.0"
 edition = "2018"
+
+license = "LGPL-3.0 OR MPL-2.0"
+# The following notice applies to all the files in this source tree:
+#
+#     This Source Code Form is subject to the terms of the Mozilla Public
+#     License, v. 2.0. If a copy of the MPL was not distributed with this
+#     file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Note that this is *in additionn* to your option to use these files
+# according to the GNU LGPL version 3.0.
+#
+# (If you copy files from this project into another program which is not
+# licenced MPL-2.0, you should add that notice to each copied file.)
 
 build = "build.rs"
 


### PR DESCRIPTION
Unlike most other Free Software licences, the MPL explicitly says it applies only to files with a specific notice:

> 1.4. "Covered Software"
> means Source Code Form to which the initial Contributor has attached
> the notice in Exhibit A, the Executable Form of such Source Code
> Form, and Modifications of such Source Code Form, in each case
> including portions thereof.

Unfortunately, this means that copying the MPL text into tree, and setting the "license" Cargo option, leaves an ambiguous situation. One might presume that the intent was to actually use the MPL for the whole project, but the legal licence text explicitly rejects that.

Thankfully, according to the licence text, it is not actually necessary to add the notice to every file:

> If it is not possible or desirable to put the notice in a particular
> file, then You may include the notice in a location (such as a LICENSE
> file in a relevant directory) where a recipient would be likely to look
> for such a notice.

So clarify this situation by adding one central explicit copy of the MPL "Exhibit A" text, and declare it to apply to everything.

Putting it in Cargo.toml puts it next to the "license =" tag. Another possibility would be README.md but IMO this legal technicality doesn't really warrant such exposure.

I added another sentence so that it's clear that this statement about
the MPL doesn't contradict the intent to also offer LGPL 3.0.

(Putting it in the LICENCE file, as the text itself suggests, would mean either (i) renaming the verbatim copy of the MPL 2.0 and writing a new file or (ii) adding it as a rubric to the top of the MPL 2.0 text in LICENCE - resulting in a LICENCE file which is not identical to the usual MPL-2.0 text file. Neither of those seem desirable.)

(FYI we, the Arti developers, have had similar MRs accepted in other projects, eg https://github.com/soc/option-ext/pull/4.  Our  original ticket for this kind of thing was https://gitlab.torproject.org/tpo/core/arti/-/issues/845)