### PR TITLE
Some licensing-related housekeeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/priority-queue"
 readme = "README.md"
 keywords = ["priority", "queue", "heap"]
 categories = ["data-structures", "algorithms"]
-license = "LGPL-3.0 OR MPL-2.0"
+license = "LGPL-3.0-or-later OR MPL-2.0"
 edition = "2021"
 
 [build-dependencies]

--- a/benches/priority_queue.rs
+++ b/benches/priority_queue.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/benches/priority_queue.rs
+++ b/benches/priority_queue.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 

--- a/src/core_iterators.rs
+++ b/src/core_iterators.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/src/core_iterators.rs
+++ b/src/core_iterators.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 //! This module defines iterator types that are used with

--- a/src/double_priority_queue/iterators.rs
+++ b/src/double_priority_queue/iterators.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/src/double_priority_queue/iterators.rs
+++ b/src/double_priority_queue/iterators.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 //! This module defines iterator types that are used only with the [`DoublePriorityQueue`]

--- a/src/double_priority_queue/mod.rs
+++ b/src/double_priority_queue/mod.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 //! This module contains the [`DoublePriorityQueue`] type and the related iterators.

--- a/src/double_priority_queue/mod.rs
+++ b/src/double_priority_queue/mod.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 

--- a/src/priority_queue/iterators.rs
+++ b/src/priority_queue/iterators.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/src/priority_queue/iterators.rs
+++ b/src/priority_queue/iterators.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 //! This module defines iterator types that are used only with the [`PriorityQueue`].

--- a/src/priority_queue/mod.rs
+++ b/src/priority_queue/mod.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/src/priority_queue/mod.rs
+++ b/src/priority_queue/mod.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 #[cfg(not(feature = "std"))]

--- a/src/store.rs
+++ b/src/store.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/test-nostd/src/lib.rs
+++ b/test-nostd/src/lib.rs
@@ -1,3 +1,31 @@
+/*
+ *  Copyright 2017 Gianmarco Garrisi and contributors
+ *
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version, or (at your option) under the terms
+ *  of the Mozilla Public License version 2.0.
+ *
+ *  ----
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
 #![no_std]
 
 use core::hash::BuildHasherDefault;

--- a/tests/double_priority_queue.rs
+++ b/tests/double_priority_queue.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/tests/double_priority_queue.rs
+++ b/tests/double_priority_queue.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 

--- a/tests/priority_queue.rs
+++ b/tests/priority_queue.rs
@@ -5,7 +5,7 @@
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Lesser General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version, or (at your opinion) under the terms
+ *  (at your option) any later version, or (at your option) under the terms
  *  of the Mozilla Public License version 2.0.
  *
  *  ----

--- a/tests/priority_queue.rs
+++ b/tests/priority_queue.rs
@@ -8,6 +8,8 @@
  *  (at your option) any later version, or (at your opinion) under the terms
  *  of the Mozilla Public License version 2.0.
  *
+ *  ----
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,6 +17,12 @@
  *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  ----
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public License,
+ *  v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ *  obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
 


### PR DESCRIPTION
Replace deprecated [`LGPL-3.0`](https://spdx.org/licenses/LGPL-3.0) SPDX identifier with [`LGPL-3.0-or-later`](https://spdx.org/licenses/LGPL-3.0-or-later].

Using [`LGPL-3.0-or-later`](https://spdx.org/licenses/LGPL-3.0-or-later) instead of [`LGPL-3.0-only`](https://spdx.org/licenses/LGPL-3.0-only) is based on the “any later version” language in the source-file headers, e.g.

https://github.com/garro95/priority-queue/blob/efe31e81194b1c3ab8510b1dc3ea9b7be470b373/src/lib.rs#L5-L9

although I note that in https://github.com/garro95/priority-queue/issues/23, contributors were asked about “LGPL 3” but not about later versions. If you believe this should be `LGPL-3.0-only`, let me know and I’ll revise the PR.

----

Add [`MPL-2.0`](https://spdx.org/licenses/MPL-2.0) “Exhibit A” text to source file headers, option “(a)” from https://github.com/garro95/priority-queue/pull/48.

----

Fix a minor typo in license/copyright headers throughout the project, which said “at your opinion” rather than “at your option.”

----

Copy the standard license/copyright comment from the other files to `test-nostd/src/lib.rs`.

@garro95 @ijackson