### PR TITLE
Make `with_hasher` const

### DIFF
--- a/src/double_priority_queue/mod.rs
+++ b/src/double_priority_queue/mod.rs
@@ -162,8 +162,10 @@ where
     H: BuildHasher,
 {
     /// Creates an empty `DoublePriorityQueue` with the specified hasher
-    pub fn with_hasher(hash_builder: H) -> Self {
-        Self::with_capacity_and_hasher(0, hash_builder)
+    pub const fn with_hasher(hash_builder: H) -> Self {
+        Self {
+            store: Store::with_hasher(hash_builder),
+        }
     }
 
     /// Creates an empty `DoublePriorityQueue` with the specified capacity and hasher

--- a/src/priority_queue/mod.rs
+++ b/src/priority_queue/mod.rs
@@ -153,8 +153,10 @@ where
     H: BuildHasher,
 {
     /// Creates an empty `PriorityQueue` with the specified hasher
-    pub fn with_hasher(hash_builder: H) -> Self {
-        Self::with_capacity_and_hasher(0, hash_builder)
+    pub const fn with_hasher(hash_builder: H) -> Self {
+        Self {
+            store: Store::with_hasher(hash_builder),
+        }
     }
 
     /// Creates an empty `PriorityQueue` with the specified capacity and hasher

--- a/src/store.rs
+++ b/src/store.rs
@@ -134,8 +134,13 @@ where
     H: BuildHasher,
 {
     /// Creates an empty `Store` with the specified hasher
-    pub fn with_hasher(hash_builder: H) -> Self {
-        Self::with_capacity_and_hasher(0, hash_builder)
+    pub const fn with_hasher(hash_builder: H) -> Self {
+        Self {
+            map: IndexMap::with_hasher(hash_builder),
+            heap: Vec::new(),
+            qp: Vec::new(),
+            size: 0,
+        }
     }
 
     /// Creates an empty `Store` with the specified capacity and hasher


### PR DESCRIPTION
`with_hasher` can be made const since [IndexMap::with_hasher](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html#method.with_hasher) is const. There is actually no memory allocation here.