### PR TITLE
fix: Make `serde` feature depend on `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ hashbrown = "0.14"
 [features]
 default = ["std"]
 std = ["indexmap/std"]
+serde = ["std", "dep:serde"]
 benchmarks = []
 
 [workspace]


### PR DESCRIPTION
As far as I can tell, the use of `serde` in this crate isn't designed to be used without `std`, although `serde` seems to support that:
https://serde.rs/no-std.html

This makes the current dependency clearer, meaning that `cargo test --no-default-features --features serde` now pass.